### PR TITLE
Docs: add architecture & AI maintenance skills, expand READMEs, fix frontend lint

### DIFF
--- a/.codex/skills/hometown-guide-maintenance/SKILL.md
+++ b/.codex/skills/hometown-guide-maintenance/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: hometown-guide-maintenance
+description: Use this skill when maintaining the My Hometown Guide React/CakePHP application, including frontend UI changes, backend API changes, docs updates, release checks, or architecture-aware refactors.
+---
+
+# Hometown Guide Maintenance
+
+Use this skill for code and documentation work in this repository.
+
+## First checks
+
+1. Read `README.md` and `docs/architecture.md` for current architecture.
+2. Inspect the files related to the requested layer:
+   - Frontend: `frontend/src/App.jsx`, `frontend/src/MapView.jsx`, `frontend/src/hooks/useFavoriteShops.js`.
+   - Backend API: `backend/src/Controller/Api/ShopsController.php`, `backend/src/Model/Table/ShopsTable.php`, `backend/src/Model/Entity/Shop.php`.
+   - Schema: `backend/config/Migrations/`, `backend/tests/Fixture/ShopsFixture.php`.
+3. Avoid changing generated dependencies or ignored runtime directories such as `frontend/node_modules`, `backend/vendor`, `backend/tmp`, and `backend/logs`.
+
+## Frontend workflow
+
+- Keep `App.jsx` as the owner of API data and filter state unless a change clearly needs extraction.
+- Keep Leaflet instances in refs, not React state.
+- If changing the public path, update both `frontend/vite.config.js` and marker asset paths in `frontend/src/MapView.jsx`.
+- When adding UI fields, handle nullable API values gracefully and keep Japanese guest-facing copy concise.
+
+## Backend workflow
+
+- Keep `/api/shops.json` response shape compatible unless the task explicitly requests a breaking API change.
+- For new shop fields, update migration, entity, table validation, fixtures/tests, frontend rendering, and docs together.
+- Treat CORS and CSRF settings carefully; write APIs need an explicit security review.
+- Prefer CakePHP conventions for controllers, table validation, and tests.
+
+## Validation
+
+Run the narrowest relevant checks first, then broader checks before finalizing.
+
+```bash
+cd frontend && npm run lint
+cd frontend && npm run build
+cd backend && composer test
+cd backend && composer cs-check
+```
+
+If a check cannot run because dependencies or services are missing, report the exact limitation and the command attempted.
+
+## References
+
+- For a compact system overview, read `references/system-map.md`.
+- For schema/API field expectations, read `../shop-data-curation/references/shop-schema.md`.

--- a/.codex/skills/hometown-guide-maintenance/references/system-map.md
+++ b/.codex/skills/hometown-guide-maintenance/references/system-map.md
@@ -1,0 +1,9 @@
+# System map
+
+- React fetches `${import.meta.env.VITE_API_URL}/api/shops.json` once in `App.jsx`.
+- API returns `{ success: true, data: shops }` from CakePHP `Api/ShopsController::index()`.
+- Client filters by `area`, `genre`, and local favorites.
+- Favorite shop IDs are stored in `localStorage.favoriteShops`.
+- Leaflet markers are recreated whenever filtered shops change.
+- Current areas: `morioka`, `kitakami`, `hanamaki`.
+- Current chooser labels: `groom`, `bride`, `both`.

--- a/.codex/skills/shop-data-curation/SKILL.md
+++ b/.codex/skills/shop-data-curation/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: shop-data-curation
+description: Use this skill when adding, reviewing, or changing shop records, shop fields, migrations, seed data, fixtures, or data-quality rules for My Hometown Guide.
+---
+
+# Shop Data Curation
+
+Use this skill for changes that affect shop data or the `shops` schema.
+
+## Data quality rules
+
+- `area` should be one of `morioka`, `kitakami`, or `hanamaki` unless the product scope changes.
+- `chosen_by` should be `groom`, `bride`, or `both`.
+- `lat` and `lng` must be valid coordinates and precise enough for map markers.
+- `open_time` and `end_time` should use `HH:MM` or `HH:MM:SS` consistently with the UI slicing behavior.
+- External links should be full HTTPS URLs where possible.
+- Guest-facing `description` and `comment` should avoid private information and be understandable without wedding-party context.
+
+## Schema/data change workflow
+
+1. Read `references/shop-schema.md`.
+2. Update CakePHP migration(s) and schema dump only if the project convention requires it.
+3. Update `Shop` entity accessible fields and PHPDoc.
+4. Update `ShopsTable` validation.
+5. Update fixtures and tests.
+6. Update frontend display or filters if the field is visible to users.
+7. Update `README.md` and `docs/architecture.md` if the public data contract changes.
+
+## Review checklist
+
+- Does the API still return `success` and `data`?
+- Are nullable fields handled in React without rendering broken labels or links?
+- Are map fields present for every visible shop?
+- Will the new data work with existing filters and favorites?

--- a/.codex/skills/shop-data-curation/references/shop-schema.md
+++ b/.codex/skills/shop-data-curation/references/shop-schema.md
@@ -1,0 +1,14 @@
+# Shop schema reference
+
+Expected `shops` fields:
+
+- Required: `id`, `name`, `address`, `description`, `lat`, `lng`, `created`, `modified`.
+- Optional display/filter fields: `area`, `comment`, `official_url`, `genre`, `price_range`, `walk_minutes_from_station`, `image_url`, `chosen_by`, `google_map_url`, `open_time`, `end_time`.
+
+Frontend assumptions:
+
+- `area` values drive the area dropdown and map center.
+- `genre` values are dynamically collected for the selected area.
+- `chosen_by` maps to Japanese labels in `App.jsx`.
+- `open_time` and `end_time` are displayed by slicing the first five characters.
+- `id` is used for React keys, DOM IDs (`shop-card-{id}`), marker lookup, and favorites.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,164 @@
 # My Hometown Guide
+
+盛岡・北上・花巻のおすすめスポットを、結婚式ゲスト向けに紹介する地図付きガイドです。React/Vite のフロントエンドと CakePHP 5 の JSON API を組み合わせ、店舗情報をカード・フィルター・Leaflet マップで表示します。
+
+## 目的
+
+- 結婚式の前後に立ち寄れる思い出の場所・飲食店・観光スポットをゲストへ案内する。
+- 地域（盛岡・北上・花巻）とジャンルで候補を絞り込み、地図上の位置と詳細カードを行き来できるようにする。
+- お気に入りをブラウザの `localStorage` に保存し、ゲストごとに行きたい場所を控えられるようにする。
+
+## 技術スタック
+
+| レイヤー | 技術 | 主な役割 |
+| --- | --- | --- |
+| Frontend | React 19 / Vite 6 / Tailwind CSS / Leaflet | UI、絞り込み、お気に入り、地図表示 |
+| Backend | CakePHP 5 / PHP 8.1 | 店舗 JSON API、DB アクセス、CORS |
+| Database | MySQL 8.0 | `shops` テーブルの永続化 |
+| Local runtime | Docker Compose | フロント・バックエンド・DB の起動 |
+| Deploy target | GitHub Pages（frontend）/ PHP 実行環境（backend） | 公開環境 |
+
+## ディレクトリ構成
+
+```text
+.
+├── frontend/                 # React/Vite アプリ
+│   ├── src/App.jsx           # 画面全体、API取得、フィルター、カード表示
+│   ├── src/MapView.jsx       # Leaflet マップとマーカー制御
+│   └── src/hooks/            # React hooks（お気に入り管理など）
+├── backend/                  # CakePHP 5 API
+│   ├── src/Controller/Api/   # JSON API コントローラ
+│   ├── src/Model/            # Shops テーブル/エンティティ
+│   ├── config/Migrations/    # shops スキーマ履歴
+│   └── tests/                # PHPUnit テスト
+├── docs/                     # アーキテクチャ・運用ドキュメント
+├── .codex/skills/            # AI エージェント向け作業スキル
+└── docker-compose.yml        # ローカル開発用サービス定義
+```
+
+## 主な機能
+
+- 地域フィルター: `morioka` / `kitakami` / `hanamaki` を切り替える。
+- ジャンルフィルター: 選択中の地域に存在するジャンルだけを表示する。
+- お気に入り: ハートボタンで店舗 ID を `favoriteShops` として `localStorage` に保存する。
+- 地図連携: 店舗カード選択で該当マーカーへズームし、マーカーのポップアップからカードへスクロールする。
+- 店舗補足情報: コメント、公式 URL、Google Map URL、価格帯、駅からの徒歩時間、営業時間、画像を表示する。
+
+## ローカル起動
+
+### 1. 環境変数・設定
+
+バックエンドのローカル設定を作成します。
+
+```bash
+cp backend/config/app_local.example.php backend/config/app_local.php
+```
+
+Docker Compose の MySQL を使う場合は、`backend/config/app_local.php` の `Datasources.default` を次の値に合わせてください。
+
+```php
+'host' => 'db',
+'username' => 'user',
+'password' => 'password',
+'database' => 'my_hometown',
+```
+
+フロントエンドは API の起点を `VITE_API_URL` で参照します。必要に応じて `frontend/.env.local` を作成してください。
+
+```bash
+VITE_API_URL=http://localhost:8000
+```
+
+### 2. Docker Compose で起動
+
+```bash
+docker compose up --build
+```
+
+- Frontend: <http://localhost:5173/my-hometown-guid/>
+- Backend API: <http://localhost:8000/api/shops.json>
+- MySQL: `localhost:3306`
+
+### 3. DB マイグレーション
+
+バックエンドコンテナ内で migrations を実行します。
+
+```bash
+docker compose exec app bin/cake migrations migrate
+```
+
+必要に応じて `shops` テーブルへ店舗データを投入してください。スキーマの詳細は [`docs/architecture.md`](docs/architecture.md) を参照してください。
+
+## 開発コマンド
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+npm run lint
+npm run build
+```
+
+### Backend
+
+```bash
+cd backend
+composer install
+composer test
+composer cs-check
+composer stan
+```
+
+## API 概要
+
+### `GET /api/shops.json`
+
+CakePHP の `Api/ShopsController::index()` が店舗一覧を JSON で返します。
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": 1,
+      "name": "店舗名",
+      "address": "住所",
+      "description": "紹介文",
+      "lat": "39.7036000",
+      "lng": "141.1527000",
+      "area": "morioka",
+      "genre": "カフェ",
+      "chosen_by": "both"
+    }
+  ]
+}
+```
+
+フロントエンドは `data` 配列をそのまま状態として保持します。API 項目を追加・変更するときは、DB migration、`Shop` entity、`ShopsTable` validation、フロントエンド表示をセットで確認してください。
+
+## AI エージェント向けメンテナンス
+
+このリポジトリには、AI で安全に保守するためのスキルを追加しています。
+
+- `.codex/skills/hometown-guide-maintenance/`: フロントエンド・バックエンドを横断する実装/調査フロー。
+- `.codex/skills/shop-data-curation/`: `shops` データの追加・更新・レビュー時の確認観点。
+
+AI に依頼するときは、次のような依頼文にすると意図が伝わりやすくなります。
+
+```text
+hometown-guide-maintenance スキルを使って、店舗カードに定休日表示を追加してください。
+shop-data-curation スキルを使って、盛岡のカフェデータを追加する migration を作ってください。
+```
+
+## アーキテクチャ資料
+
+詳細は [`docs/architecture.md`](docs/architecture.md) を参照してください。データフロー、主要コンポーネント、スキーマ、運用時の注意点をまとめています。
+
+## リリース・運用メモ
+
+- `frontend/vite.config.js` の `base` は `/my-hometown-guid/` です。GitHub Pages 以外へ配信するときは公開パスに合わせて変更してください。
+- Leaflet の marker assets は `/my-hometown-guid/marker-icon.png` などを参照します。公開パスを変える場合は `frontend/src/MapView.jsx` も確認してください。
+- CORS は現状 `*` 許可です。公開 API として制限したい場合は `backend/src/Middleware/CorsMiddleware.php` を環境別に調整してください。
+- API は全店舗を一括取得します。店舗数が増えた場合はバックエンド側のページネーションや地域/ジャンルクエリを検討してください。

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,53 +1,85 @@
-# CakePHP Application Skeleton
+# Backend
 
-![Build Status](https://github.com/cakephp/app/actions/workflows/ci.yml/badge.svg?branch=5.x)
-[![Total Downloads](https://img.shields.io/packagist/dt/cakephp/app.svg?style=flat-square)](https://packagist.org/packages/cakephp/app)
-[![PHPStan](https://img.shields.io/badge/PHPStan-level%208-brightgreen.svg?style=flat-square)](https://github.com/phpstan/phpstan)
+CakePHP 5 製の My Hometown Guide API です。MySQL の `shops` テーブルから店舗情報を取得し、フロントエンド向けに JSON を返します。
 
-A skeleton for creating applications with [CakePHP](https://cakephp.org) 5.x.
+## Stack
 
-The framework source code can be found here: [cakephp/cakephp](https://github.com/cakephp/cakephp).
+- PHP 8.1+
+- CakePHP 5.2
+- cakephp/migrations 4
+- MySQL 8.0
+- PHPUnit / PHPCS / PHPStan
 
-## Installation
-
-1. Download [Composer](https://getcomposer.org/doc/00-intro.md) or update `composer self-update`.
-2. Run `php composer.phar create-project --prefer-dist cakephp/app [app_name]`.
-
-If Composer is installed globally, run
+## Setup
 
 ```bash
-composer create-project --prefer-dist cakephp/app
+composer install
+cp config/app_local.example.php config/app_local.php
 ```
 
-In case you want to use a custom app dir name (e.g. `/myapp/`):
+Docker Compose の DB を使う場合は `config/app_local.php` の datasource を次に合わせます。
+
+```php
+'host' => 'db',
+'username' => 'user',
+'password' => 'password',
+'database' => 'my_hometown',
+```
+
+マイグレーションを実行します。
 
 ```bash
-composer create-project --prefer-dist cakephp/app myapp
+bin/cake migrations migrate
 ```
 
-You can now either use your machine's webserver to view the default home page, or start
-up the built-in webserver with:
+## Commands
 
 ```bash
-bin/cake server -p 8765
+composer test      # PHPUnit
+composer cs-check  # CakePHP coding standard
+composer cs-fix    # 自動整形
+composer stan      # PHPStan
 ```
 
-Then visit `http://localhost:8765` to see the welcome page.
+## API
 
-## Update
+### `GET /api/shops.json`
 
-Since this skeleton is a starting point for your application and various files
-would have been modified as per your needs, there isn't a way to provide
-automated upgrades, so you have to do any updates manually.
+`src/Controller/Api/ShopsController.php` の `index()` が次の JSON を返します。
 
-## Configuration
+```json
+{
+  "success": true,
+  "data": []
+}
+```
 
-Read and edit the environment specific `config/app_local.php` and set up the
-`'Datasources'` and any other configuration relevant for your application.
-Other environment agnostic settings can be changed in `config/app.php`.
+`data` には `Shop` entity の一覧が入ります。フロントエンドとの互換性を保つため、レスポンスのトップレベルキーを変更するときは `frontend/src/App.jsx` も更新してください。
 
-## Layout
+## Main files
 
-The app skeleton uses [Milligram](https://milligram.io/) (v1.3) minimalist CSS
-framework by default. You can, however, replace it with any other library or
-custom styles.
+| File | Role |
+| --- | --- |
+| `src/Controller/Api/ShopsController.php` | 店舗一覧 JSON API。 |
+| `src/Model/Table/ShopsTable.php` | `shops` validation と Timestamp behavior。 |
+| `src/Model/Entity/Shop.php` | shop fields と mass assignment 設定。 |
+| `src/Middleware/CorsMiddleware.php` | API 用 CORS headers。 |
+| `config/routes.php` | `/api` prefix と `.json` extension routing。 |
+| `config/Migrations/` | `shops` table の schema history。 |
+| `tests/Fixture/ShopsFixture.php` | shops テストデータ。 |
+
+## Change checklist
+
+店舗フィールドを変更するときは、以下を同じ変更セットで確認してください。
+
+1. migration
+2. `Shop` entity PHPDoc / `$_accessible`
+3. `ShopsTable` validation
+4. fixture / tests
+5. frontend display/filter logic
+6. `README.md` / `docs/architecture.md` / `.codex/skills` の必要箇所
+
+## Security notes
+
+- `/api/` は CSRF check を skip しています。write API を追加するときは認証・CSRF・CORS の方針を明示してください。
+- CORS は現状 `*` です。公開環境では許可 origin の限定を検討してください。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,178 @@
+# Architecture
+
+このドキュメントは、My Hometown Guide を AI や新しい開発者が安全に保守するための設計メモです。
+
+## 全体像
+
+```mermaid
+flowchart LR
+  Guest[ゲストのブラウザ] -->|GET /my-hometown-guid/| Frontend[React / Vite]
+  Frontend -->|GET VITE_API_URL/api/shops.json| API[CakePHP Api/ShopsController]
+  API --> ShopsTable[ShopsTable / ORM]
+  ShopsTable --> DB[(MySQL shops)]
+  Frontend --> LocalStorage[(localStorage favoriteShops)]
+  Frontend --> Tiles[OpenStreetMap tiles]
+```
+
+- フロントエンドは初回表示時に店舗一覧を API から取得し、以降の地域・ジャンル・お気に入り絞り込みはクライアント側で行います。
+- バックエンドは `/api/shops.json` で `shops` テーブル全件を JSON として返します。
+- お気に入りはサーバーに保存せず、ブラウザごとの `localStorage` に保存します。
+- 地図タイルは OpenStreetMap を利用します。
+
+## Frontend architecture
+
+### Entry points
+
+| ファイル | 役割 |
+| --- | --- |
+| `frontend/src/main.jsx` | React root のマウント。 |
+| `frontend/src/App.jsx` | API 取得、表示状態、フィルター、店舗カード表示。 |
+| `frontend/src/MapView.jsx` | Leaflet map lifecycle、marker/popup、カードへのスクロール連携。 |
+| `frontend/src/hooks/useFavoriteShops.js` | `localStorage` と React state を同期するお気に入り hook。 |
+
+### State ownership
+
+`App.jsx` が画面状態の中心です。
+
+| state | 用途 |
+| --- | --- |
+| `shops` | API から取得した店舗一覧。 |
+| `selectedShop` | カードクリック時に地図を該当店舗へ移動するための選択状態。 |
+| `selectedArea` | 表示対象地域。初期値は `morioka`。 |
+| `selectedGenre` | 表示対象ジャンル。地域変更時に `all` へ戻す。 |
+| `showOnlyFavorites` | お気に入り店舗のみ表示するか。 |
+
+`useFavoriteShops()` は `favorites`, `toggleFavorite`, `isFavorite` を返し、`favoriteShops` というキーで `localStorage` に保存します。
+
+### Map behavior
+
+`MapView.jsx` は Leaflet の mutable object を React state ではなく `useRef` で保持します。
+
+- `mapRef`: Leaflet map instance。
+- `mapContainerRef`: map を描画する DOM element。
+- `markersRef`: 店舗 ID ごとの marker instance。
+
+注意点:
+
+- `shops` が変わるたびに既存 marker を削除して再生成します。
+- 地域変更時は `areaCenters` の座標へ `setView()` します。
+- 店舗カードクリックで `selectedShop` が変わると、該当 marker の popup を開きます。
+- popup HTML に店舗名・コメントを入れるため、将来的にユーザー入力データを扱う場合は XSS 対策を再確認してください。
+
+### Build/deploy assumptions
+
+- Vite の `base` は `/my-hometown-guid/` です。
+- Leaflet marker assets も同じ公開パスを前提にしています。
+- API の origin は `VITE_API_URL` で切り替えます。
+
+## Backend architecture
+
+### Request flow
+
+```mermaid
+sequenceDiagram
+  participant Browser
+  participant Cake as CakePHP Middleware
+  participant Controller as Api/ShopsController
+  participant ORM as ShopsTable
+  participant DB as MySQL
+
+  Browser->>Cake: GET /api/shops.json
+  Cake->>Cake: Routing / BodyParser / CSRF skip / CORS
+  Cake->>Controller: index()
+  Controller->>ORM: find()->all()
+  ORM->>DB: SELECT * FROM shops
+  DB-->>ORM: rows
+  Controller-->>Browser: { success: true, data: shops }
+```
+
+### API layer
+
+`backend/src/Controller/Api/ShopsController.php` は `JsonView` を利用する設定を持ちつつ、`index()` では明示的に JSON response body を組み立てています。現状は read-only な一覧 API です。
+
+将来的に登録・更新 API を追加する場合は、次を合わせて設計してください。
+
+- CORS の許可 origin / method。
+- CSRF skip 対象を API 全体にするか、read-only 以外は別制御にするか。
+- バリデーションエラーの JSON 形式。
+- 認証・認可の有無。
+
+### Middleware
+
+`backend/src/Application.php` で次の順に middleware を積んでいます。
+
+1. Error handler
+2. Asset middleware
+3. Routing middleware
+4. Body parser
+5. CSRF protection（`/api/` は skip）
+6. CORS middleware
+
+`backend/src/Middleware/CorsMiddleware.php` は `Access-Control-Allow-Origin: *` を返します。公開後の安全性を高める場合は、環境変数や設定値から許可 origin を限定する方針に変更してください。
+
+## Data model
+
+### `shops` table
+
+| カラム | 型/制約の概要 | 用途 |
+| --- | --- | --- |
+| `id` | primary key | 店舗 ID。お気に入り保存にも使用。 |
+| `name` | string, required | 店舗名。 |
+| `address` | string, required | 住所。 |
+| `description` | text, required | カード本文。 |
+| `lat` / `lng` | decimal, required | Leaflet marker の座標。 |
+| `area` | string, nullable | `morioka` / `kitakami` / `hanamaki` を想定。 |
+| `comment` | text, nullable | map popup などの短いコメント。 |
+| `official_url` | string, nullable | 公式サイトリンク。 |
+| `genre` | string, nullable | ジャンルフィルター。 |
+| `price_range` | string, nullable | 価格帯表示。 |
+| `walk_minutes_from_station` | integer, nullable | 駅からの徒歩分数。 |
+| `image_url` | text, nullable | カード画像 URL。 |
+| `chosen_by` | enum/string, nullable | `groom` / `bride` / `both`。 |
+| `google_map_url` | text, nullable | Google Maps への外部リンク。 |
+| `open_time` / `end_time` | string, nullable | `HH:MM` 形式を想定した営業時間。 |
+| `created` / `modified` | datetime | CakePHP Timestamp behavior。 |
+
+### Field change checklist
+
+店舗フィールドを追加・変更するときは、最低限次を同じ PR で確認します。
+
+1. `backend/config/Migrations/` に migration を追加する。
+2. `backend/src/Model/Entity/Shop.php` の property と `$_accessible` を更新する。
+3. `backend/src/Model/Table/ShopsTable.php` の validation を更新する。
+4. `backend/tests/Fixture/ShopsFixture.php` と関連テストを更新する。
+5. `frontend/src/App.jsx` または `MapView.jsx` の表示・絞り込み・リンクを更新する。
+6. README / architecture / skill の説明に影響があれば更新する。
+
+## Operational concerns
+
+### Performance
+
+現状は店舗数が少ない前提で全件取得・クライアントフィルターです。数百件を超える場合は、API に `area`, `genre`, `favorite ids` などのクエリを追加し、DB 側で絞り込む設計を検討してください。
+
+### Security
+
+- CORS は `*` のため、API を公開する場合は必要な origin に限定することを推奨します。
+- API は read-only ですが、今後 write API を追加する場合は認証・CSRF・rate limit を検討してください。
+- `MapView.jsx` の popup は HTML を組み立てています。管理者以外が入力するデータを表示する場合はエスケープ方針を見直してください。
+
+### Reliability
+
+- `VITE_API_URL` が未設定だと API URL が `undefined/api/shops.json` になります。環境ごとに `.env` / CI / hosting secret を確認してください。
+- 公開パスを変える場合は Vite `base` と Leaflet marker asset path を同時に変更してください。
+- `localStorage` が利用できない環境でも hook 初期化時は fallback しますが、保存時の例外は現状捕捉していません。
+
+## Recommended validation before release
+
+```bash
+cd frontend && npm run lint && npm run build
+cd backend && composer test && composer cs-check
+```
+
+DB migration や API 変更を含む場合は、ローカルまたは検証環境で次も確認します。
+
+```bash
+docker compose up --build
+docker compose exec app bin/cake migrations migrate
+curl http://localhost:8000/api/shops.json
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,63 @@
-# React + Vite
+# Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React/Vite 製の My Hometown Guide フロントエンドです。CakePHP API から店舗一覧を取得し、地域・ジャンル・お気に入りで絞り込んだカードと Leaflet マップを表示します。
 
-Currently, two official plugins are available:
+## Stack
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- React 19
+- Vite 6
+- Tailwind CSS 3
+- Axios
+- Leaflet
 
-## Expanding the ESLint configuration
+## Setup
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```bash
+npm install
+```
+
+API の起点は `VITE_API_URL` で指定します。ローカル API を使う場合は `frontend/.env.local` を作成してください。
+
+```bash
+VITE_API_URL=http://localhost:8000
+```
+
+## Commands
+
+```bash
+npm run dev      # 開発サーバー
+npm run lint     # ESLint
+npm run build    # 本番ビルド
+npm run preview  # dist のプレビュー
+npm run deploy   # gh-pages へ dist を公開
+```
+
+## Key files
+
+| File | Role |
+| --- | --- |
+| `src/App.jsx` | API fetch、フィルター状態、店舗カード、お気に入り UI。 |
+| `src/MapView.jsx` | Leaflet map lifecycle、marker、popup、カードへのスクロール連携。 |
+| `src/hooks/useFavoriteShops.js` | `localStorage.favoriteShops` でお気に入り ID を永続化。 |
+| `vite.config.js` | GitHub Pages 向け `base: '/my-hometown-guid/'`。 |
+| `tailwind.config.js` | wedding-themed colors/font settings。 |
+
+## API contract
+
+`src/App.jsx` は次の形式を期待します。
+
+```json
+{
+  "success": true,
+  "data": []
+}
+```
+
+各 shop の主なフィールドは `id`, `name`, `address`, `description`, `lat`, `lng`, `area`, `genre`, `chosen_by`, `official_url`, `google_map_url`, `open_time`, `end_time` です。
+
+## Implementation notes
+
+- `area` は `morioka`, `kitakami`, `hanamaki` を想定しています。
+- `selectedArea` が変わると `selectedGenre` は `all` に戻ります。
+- `open_time` / `end_time` は先頭 5 文字を表示するため、`HH:MM` または `HH:MM:SS` の形式にしてください。
+- 公開パスを変える場合は `vite.config.js` の `base` と `MapView.jsx` の marker asset path を同時に確認してください。

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,7 @@ function App() {
   const [selectedGenre, setSelectedGenre] = useState('all');
   const [showOnlyFavorites, setShowOnlyFavorites] = useState(false);
 
-  const { favorites, toggleFavorite, isFavorite } = useFavoriteShops();
+  const { toggleFavorite, isFavorite } = useFavoriteShops();
 
   useEffect(() => {
     axios


### PR DESCRIPTION
### Motivation

- Improve project onboarding and maintenance by expanding documentation (README, frontend/backend guides) and providing an architecture reference. 
- Make the repository AI-friendly by adding structured skills for automated/assistant-driven maintenance and shop data curation. 
- Reduce friction for future UI changes by codifying expectations about API shape and frontend/backend change checklist. 
- Fix a small frontend lint issue to keep the developer workflow clean.

### Description

- Expanded the top-level `README.md` with purpose, tech stack, directory layout, local run instructions, API contract, and operational notes. 
- Added `docs/architecture.md` describing data flow, frontend/backend responsibilities, middleware, `shops` schema, and a field-change checklist. 
- Added AI maintenance skills under `.codex/skills/`: `hometown-guide-maintenance` and `shop-data-curation` with compact references (`system-map.md`, `shop-schema.md`) to guide automated agents. 
- Updated `frontend/README.md` and `backend/README.md` to the project-specific setup/commands/API contract and removed an unused `favorites` binding in `frontend/src/App.jsx` to resolve an ESLint error.

### Testing

- Ran `cd frontend && npm run lint`, which completed successfully after the unused-variable fix and left two `react-hooks/exhaustive-deps` warnings. 
- Ran `cd frontend && npm run build`, which succeeded with non-blocking warnings about Browserslist and a runtime `bg-texture.jpg` asset resolution. 
- Attempted `cd backend && composer test` but `phpunit` was not available in the environment so tests could not be executed. 
- Attempted backend dependency install; `composer install` initially failed due to platform PHP version mismatch, and `composer install --ignore-platform-req=php` proceeded but was interrupted by upstream artifact (GitHub zipball) download errors (HTTP 403), so full backend validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09679429c48333b4b0beeb6f187949)